### PR TITLE
set TRANSFER_STATES.ERROR state on error

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -227,6 +227,7 @@ const ConnextModal: FC<ConnextModalProps> = ({
     }
     setError(e);
     setIsError(true);
+    setTransferState(TRANSFER_STATES.ERROR)
     setIniting(false);
     setPreImage(undefined);
   };


### PR DESCRIPTION
Currently it stays in DEPOSITING state on error (i.e., if metamask rejects the transaction) and the modal is unclosable. 