### PR TITLE
Disable resetCSS option for ChakraProvider

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1338,7 +1338,7 @@ const ConnextModal: FC<ConnextModalProps> = ({
 
   return (
     <>
-      <ChakraProvider theme={theme}>
+      <ChakraProvider resetCSS={false} theme={theme}>
         <Fonts />
         <Modal
           id="modal"


### PR DESCRIPTION
The resetCSS breaks a lot of the css on our page; this fixes most* of the issues. With `resetCSS={false} `everything in the modal looks good/ the same to me, but I don't fully understand the implications of this change, so you should make sure I didn't break any of your styling.


(*interestingly/strangely, there is one issue that this doesn't resolve: the background color of `<body>` is still getting overridden somewhere. We can just handle this on our end with an `!important` flag, but just as a heads up.)