### PR TITLE
[DNM] Remove Chakra framework, develop in-house UI solution as replacement

### DIFF
--- a/src/components/subcomponents/Box.tsx
+++ b/src/components/subcomponents/Box.tsx
@@ -1,0 +1,4 @@
+/// TODO: Replace Chakra Box component. This should be extremely simple, just a div (column) with flex row.
+/// We may need to fine tune the sizing for mobile, etc., however.
+/// Also, we may want to rename from Box -> Column or something, as Stack may be Chakra-exclusive terminology.
+/// See also: Box.tsx

--- a/src/components/subcomponents/Button.tsx
+++ b/src/components/subcomponents/Button.tsx
@@ -1,0 +1,106 @@
+/// TODO: Adapt Chakra Button
+/// May want to make a general purpose button, and then subclass for specific types, i.e. one for back button,
+/// one for hamburger dropdown menu, one with text/linking, etc.
+
+// var Button = /*#__PURE__*/(0, _system.forwardRef)(function (props, ref) {
+//   var _styles$_focus;
+
+//   var group = (0, _buttonGroup.useButtonGroup)();
+//   var styles = (0, _system.useStyleConfig)("Button", _extends({}, group, props));
+
+//   var _omitThemingProps = (0, _system.omitThemingProps)(props),
+//       _omitThemingProps$isD = _omitThemingProps.isDisabled,
+//       isDisabled = _omitThemingProps$isD === void 0 ? group == null ? void 0 : group.isDisabled : _omitThemingProps$isD,
+//       isLoading = _omitThemingProps.isLoading,
+//       isActive = _omitThemingProps.isActive,
+//       isFullWidth = _omitThemingProps.isFullWidth,
+//       children = _omitThemingProps.children,
+//       leftIcon = _omitThemingProps.leftIcon,
+//       rightIcon = _omitThemingProps.rightIcon,
+//       loadingText = _omitThemingProps.loadingText,
+//       _omitThemingProps$ico = _omitThemingProps.iconSpacing,
+//       iconSpacing = _omitThemingProps$ico === void 0 ? "0.5rem" : _omitThemingProps$ico,
+//       _omitThemingProps$typ = _omitThemingProps.type,
+//       type = _omitThemingProps$typ === void 0 ? "button" : _omitThemingProps$typ,
+//       spinner = _omitThemingProps.spinner,
+//       className = _omitThemingProps.className,
+//       as = _omitThemingProps.as,
+//       rest = _objectWithoutPropertiesLoose(_omitThemingProps, ["isDisabled", "isLoading", "isActive", "isFullWidth", "children", "leftIcon", "rightIcon", "loadingText", "iconSpacing", "type", "spinner", "className", "as"]);
+//   /**
+//    * When button is used within ButtonGroup (i.e flushed with sibling buttons),
+//    * it is important to add a `zIndex` on focus.
+//    *
+//    * So let's read the component styles and then add `zIndex` to it.
+//    */
+
+
+//   var _focus = (0, _utils.mergeWith)({}, (_styles$_focus = styles == null ? void 0 : styles["_focus"]) != null ? _styles$_focus : {}, {
+//     zIndex: 1
+//   });
+
+//   var buttonStyles = _extends({
+//     display: "inline-flex",
+//     appearance: "none",
+//     alignItems: "center",
+//     justifyContent: "center",
+//     transition: "all 250ms",
+//     userSelect: "none",
+//     position: "relative",
+//     whiteSpace: "nowrap",
+//     verticalAlign: "middle",
+//     outline: "none",
+//     width: isFullWidth ? "100%" : "auto"
+//   }, styles, !!group && {
+//     _focus: _focus
+//   });
+
+//   return /*#__PURE__*/React.createElement(_system.chakra.button, _extends({
+//     disabled: isDisabled || isLoading,
+//     ref: ref,
+//     as: as,
+//     type: as ? undefined : type,
+//     "data-active": (0, _utils.dataAttr)(isActive),
+//     "data-loading": (0, _utils.dataAttr)(isLoading),
+//     __css: buttonStyles,
+//     className: (0, _utils.cx)("chakra-button", className)
+//   }, rest), leftIcon && !isLoading && /*#__PURE__*/React.createElement(ButtonIcon, {
+//     marginEnd: iconSpacing
+//   }, leftIcon), isLoading && /*#__PURE__*/React.createElement(ButtonSpinner, {
+//     __css: {
+//       fontSize: "1em",
+//       lineHeight: "normal"
+//     },
+//     spacing: iconSpacing,
+//     label: loadingText
+//   }, spinner), isLoading ? loadingText || /*#__PURE__*/React.createElement(_system.chakra.span, {
+//     opacity: 0
+//   }, children) : children, rightIcon && !isLoading && /*#__PURE__*/React.createElement(ButtonIcon, {
+//     marginStart: iconSpacing
+//   }, rightIcon));
+// });
+// exports.Button = Button;
+
+// if (_utils.__DEV__) {
+//   Button.displayName = "Button";
+// }
+
+// var ButtonIcon = function ButtonIcon(props) {
+//   var children = props.children,
+//       className = props.className,
+//       rest = _objectWithoutPropertiesLoose(props, ["children", "className"]);
+
+//   var _children = /*#__PURE__*/React.isValidElement(children) ? /*#__PURE__*/React.cloneElement(children, {
+//     "aria-hidden": true,
+//     focusable: false
+//   }) : children;
+
+//   var _className = (0, _utils.cx)("chakra-button__icon", className);
+
+//   return /*#__PURE__*/React.createElement(_system.chakra.span, _extends({}, rest, {
+//     className: _className
+//   }), _children);
+// };
+
+// if (_utils.__DEV__) {
+//   ButtonIcon.displayName = "ButtonIcon";
+// }

--- a/src/components/subcomponents/Icon.tsx
+++ b/src/components/subcomponents/Icon.tsx
@@ -1,0 +1,25 @@
+/// TODO: Adapt Chakra Icon
+/// Note that since we aren't using the Chakra framework anymore, we might not be entitled to the same licensing for
+/// these svg's and may need to find replacements for them from Noun Project, etc.
+
+/// Icons used:
+// Hamburger Dropdown:
+//     <svg viewBox="0 0 24 24" focusable="false" className="chakra-icon connext-modal-nikkw0" aria-hidden="true">
+//       <path fill="currentColor" d="M 3 5 A 1.0001 1.0001 0 1 0 3 7 L 21 7 A 1.0001 1.0001 0 1 0 21 5 L 3 5 z M 3 11 A 1.0001 1.0001 0 1 0 3 13 L 21 13 A 1.0001 1.0001 0 1 0 21 11 L 3 11 z M 3 17 A 1.0001 1.0001 0 1 0 3 19 L 21 19 A 1.0001 1.0001 0 1 0 21 17 L 3 17 z"></path>
+//     </svg>
+// Back Arrow:
+//     <svg viewBox="0 0 24 24" focusable="false" className="chakra-icon connext-modal-nikkw0" aria-hidden="true">
+//       <path fill="currentColor" d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"></path>
+//     </svg>
+// Warning !:
+// <svg viewBox="0 0 24 24" focusable="false" class="chakra-icon connext-modal-onkibi"><path fill="currentColor" d="M23.119,20,13.772,2.15h0a2,2,0,0,0-3.543,0L.881,20a2,2,0,0,0,1.772,2.928H21.347A2,2,0,0,0,23.119,20ZM11,8.423a1,1,0,0,1,2,0v6a1,1,0,1,1-2,0Zm1.05,11.51h-.028a1.528,1.528,0,0,1-1.522-1.47,1.476,1.476,0,0,1,1.448-1.53h.028A1.527,1.527,0,0,1,13.5,18.4,1.475,1.475,0,0,1,12.05,19.933Z"></path></svg>
+// Close Icon:
+// TODO
+
+/// Alternatively, may create separate subcomponents for each item here.
+
+// import React, { FC, useEffect, useState } from 'react';
+// const Icon: FC<> = props => {
+// };
+
+

--- a/src/components/subcomponents/ModalBase.tsx
+++ b/src/components/subcomponents/ModalBase.tsx
@@ -1,0 +1,136 @@
+
+/// TODO: Adapt Chakra Modal component. We'll call it the ModalBase to distinguish
+
+// function useModal(props) {
+//   var isOpen = props.isOpen,
+//       onClose = props.onClose,
+//       id = props.id,
+//       _props$closeOnOverlay = props.closeOnOverlayClick,
+//       closeOnOverlayClick = _props$closeOnOverlay === void 0 ? true : _props$closeOnOverlay,
+//       _props$closeOnEsc = props.closeOnEsc,
+//       closeOnEsc = _props$closeOnEsc === void 0 ? true : _props$closeOnEsc,
+//       _props$useInert = props.useInert,
+//       useInert = _props$useInert === void 0 ? true : _props$useInert,
+//       onOverlayClickProp = props.onOverlayClick,
+//       onEsc = props.onEsc;
+//   var dialogRef = (0, _react.useRef)(null);
+//   var overlayRef = (0, _react.useRef)(null);
+
+//   var _useIds = (0, _hooks.useIds)(id, "chakra-modal", "chakra-modal--header", "chakra-modal--body"),
+//       dialogId = _useIds[0],
+//       headerId = _useIds[1],
+//       bodyId = _useIds[2];
+//   /**
+//    * Hook used to polyfill `aria-modal` for older browsers.
+//    * It uses `aria-hidden` to all other nodes.
+//    *
+//    * @see https://developer.paciellogroup.com/blog/2018/06/the-current-state-of-modal-dialog-accessibility/
+//    */
+
+
+//   useAriaHidden(dialogRef, isOpen && useInert);
+//   /**
+//    * Hook use to manage multiple or nested modals
+//    */
+
+//   (0, _modalManager.useModalManager)(dialogRef, isOpen);
+//   var mouseDownTarget = (0, _react.useRef)(null);
+//   var onMouseDown = (0, _react.useCallback)(function (event) {
+//     mouseDownTarget.current = event.target;
+//   }, []);
+//   var onKeyDown = (0, _react.useCallback)(function (event) {
+//     if (event.key === "Escape") {
+//       event.stopPropagation();
+
+//       if (closeOnEsc) {
+//         onClose == null ? void 0 : onClose();
+//       }
+
+//       onEsc == null ? void 0 : onEsc();
+//     }
+//   }, [closeOnEsc, onClose, onEsc]);
+
+//   var _useState = (0, _react.useState)(false),
+//       headerMounted = _useState[0],
+//       setHeaderMounted = _useState[1];
+
+//   var _useState2 = (0, _react.useState)(false),
+//       bodyMounted = _useState2[0],
+//       setBodyMounted = _useState2[1];
+
+//   var getDialogProps = (0, _react.useCallback)(function (props, ref) {
+//     if (props === void 0) {
+//       props = {};
+//     }
+
+//     if (ref === void 0) {
+//       ref = null;
+//     }
+
+//     return _extends({
+//       role: "dialog"
+//     }, props, {
+//       ref: (0, _utils.mergeRefs)(ref, dialogRef),
+//       id: dialogId,
+//       tabIndex: -1,
+//       "aria-modal": true,
+//       "aria-labelledby": headerMounted ? headerId : undefined,
+//       "aria-describedby": bodyMounted ? bodyId : undefined,
+//       onClick: (0, _utils.callAllHandlers)(props.onClick, function (event) {
+//         return event.stopPropagation();
+//       })
+//     });
+//   }, [bodyId, bodyMounted, dialogId, headerId, headerMounted]);
+//   var onOverlayClick = (0, _react.useCallback)(function (event) {
+//     event.stopPropagation();
+//     /**
+//      * Make sure the event starts and ends on the same DOM element.
+//      *
+//      * This is used to prevent the modal from closing when you
+//      * start dragging from the content, and release drag outside the content.
+//      *
+//      * We prevent this because it is technically not a considered "click outside"
+//      */
+
+//     if (mouseDownTarget.current !== event.target) return;
+//     /**
+//      * When you click on the overlay, we want to remove only the topmost modal
+//      */
+
+//     if (!_modalManager.manager.isTopModal(dialogRef)) return;
+
+//     if (closeOnOverlayClick) {
+//       onClose == null ? void 0 : onClose();
+//     }
+
+//     onOverlayClickProp == null ? void 0 : onOverlayClickProp();
+//   }, [onClose, closeOnOverlayClick, onOverlayClickProp]);
+//   var getDialogContainerProps = (0, _react.useCallback)(function (props, ref) {
+//     if (props === void 0) {
+//       props = {};
+//     }
+
+//     if (ref === void 0) {
+//       ref = null;
+//     }
+
+//     return _extends({}, props, {
+//       ref: (0, _utils.mergeRefs)(ref, overlayRef),
+//       onClick: (0, _utils.callAllHandlers)(props.onClick, onOverlayClick),
+//       onKeyDown: (0, _utils.callAllHandlers)(props.onKeyDown, onKeyDown),
+//       onMouseDown: (0, _utils.callAllHandlers)(props.onMouseDown, onMouseDown)
+//     });
+//   }, [onKeyDown, onMouseDown, onOverlayClick]);
+//   return {
+//     isOpen: isOpen,
+//     onClose: onClose,
+//     headerId: headerId,
+//     bodyId: bodyId,
+//     setBodyMounted: setBodyMounted,
+//     setHeaderMounted: setHeaderMounted,
+//     dialogRef: dialogRef,
+//     overlayRef: overlayRef,
+//     getDialogProps: getDialogProps,
+//     getDialogContainerProps: getDialogContainerProps
+//   };
+// }

--- a/src/components/subcomponents/ModalContent.tsx
+++ b/src/components/subcomponents/ModalContent.tsx
@@ -1,0 +1,75 @@
+/// TODO: Create a substitute for ModalContent component from Chakra.
+/// This should also replace ModalBody - I believe the similarity/redundancy across all 'Screens' in terms of
+/// UI merits that abstraction - we won't need both, as the body can just be passed into the content and injected/nested
+/// here however we like.
+
+// import React, { FC, useEffect, useState } from 'react';
+// import CSS from 'csstype';
+
+// Modal.defaultProps = {
+//   lockFocusAcrossFrames: true,
+//   returnFocusOnClose: true,
+//   scrollBehavior: "outside",
+//   trapFocus: true,
+//   autoFocus: true,
+//   blockScrollOnMount: true,
+//   allowPinchZoom: false,
+//   motionPreset: "scale"
+// };
+
+// var ModalBody = /*#__PURE__*/(0, _system.forwardRef)(function (props, ref) {
+//   var className = props.className,
+//       rest = _objectWithoutPropertiesLoose(props, ["className"]);
+
+//   var _useModalContext6 = useModalContext(),
+//       bodyId = _useModalContext6.bodyId,
+//       setBodyMounted = _useModalContext6.setBodyMounted;
+//   /**
+//    * Notify us if this component was rendered or used
+//    * so we can append `aria-describedby` automatically
+//    */
+
+
+//   React.useEffect(function () {
+//     setBodyMounted(true);
+//     return function () {
+//       return setBodyMounted(false);
+//     };
+//   }, [setBodyMounted]);
+
+//   var _className = (0, _utils.cx)("chakra-modal__body", className);
+
+//   var styles = (0, _system.useStyles)();
+//   return /*#__PURE__*/React.createElement(_system.chakra.div, _extends({
+//     ref: ref,
+//     className: _className,
+//     id: bodyId
+//   }, rest, {
+//     __css: styles.body
+//   }));
+// });
+// exports.ModalBody = ModalBody;
+
+// if (_utils.__DEV__) {
+//   ModalBody.displayName = "ModalBody";
+// }
+
+
+// const styleModalContent: CSS.Properties = {
+//   backgroundImage: `url(${graphic})`,
+//   backgroundColor: '#F5F5F5',
+//   border: '2px solid #4D4D4D',
+//   boxSizing: 'border-box',
+//   borderRadius: '15px',
+//   padding: '0.5rem',
+//   backgroundRepeat: 'no-repeat',
+// };
+
+// const ModalContent: FC<TransferProps> = props => {
+
+//   return (
+//     <>
+
+//     </>
+//   )
+// };

--- a/src/components/subcomponents/ModalFooter.tsx
+++ b/src/components/subcomponents/ModalFooter.tsx
@@ -1,0 +1,28 @@
+/// TODO: Adapt Chakra ModalFooter
+
+// var ModalFooter = /*#__PURE__*/(0, _system.forwardRef)(function (props, ref) {
+//   var className = props.className,
+//       rest = _objectWithoutPropertiesLoose(props, ["className"]);
+
+//   var _className = (0, _utils.cx)("chakra-modal__footer", className);
+
+//   var styles = (0, _system.useStyles)();
+
+//   var footerStyles = _extends({
+//     display: "flex",
+//     alignItems: "center",
+//     justifyContent: "flex-end"
+//   }, styles.footer);
+
+//   return /*#__PURE__*/React.createElement(_system.chakra.footer, _extends({
+//     ref: ref
+//   }, rest, {
+//     __css: footerStyles,
+//     className: _className
+//   }));
+// });
+// exports.ModalFooter = ModalFooter;
+
+// if (_utils.__DEV__) {
+//   ModalFooter.displayName = "ModalFooter";
+// }

--- a/src/components/subcomponents/ModalHeader.tsx
+++ b/src/components/subcomponents/ModalHeader.tsx
@@ -1,0 +1,43 @@
+/// TODO: Adapt Chakra ModalHeader
+
+// var ModalHeader = /*#__PURE__*/(0, _system.forwardRef)(function (props, ref) {
+//   var className = props.className,
+//       rest = _objectWithoutPropertiesLoose(props, ["className"]);
+
+//   var _useModalContext5 = useModalContext(),
+//       headerId = _useModalContext5.headerId,
+//       setHeaderMounted = _useModalContext5.setHeaderMounted;
+//   /**
+//    * Notify us if this component was rendered or used
+//    * so we can append `aria-labelledby` automatically
+//    */
+
+
+//   React.useEffect(function () {
+//     setHeaderMounted(true);
+//     return function () {
+//       return setHeaderMounted(false);
+//     };
+//   }, [setHeaderMounted]);
+
+//   var _className = (0, _utils.cx)("chakra-modal__header", className);
+
+//   var styles = (0, _system.useStyles)();
+
+//   var headerStyles = _extends({
+//     flex: 0
+//   }, styles.header);
+
+//   return /*#__PURE__*/React.createElement(_system.chakra.header, _extends({
+//     ref: ref,
+//     className: _className,
+//     id: headerId
+//   }, rest, {
+//     __css: headerStyles
+//   }));
+// });
+// exports.ModalHeader = ModalHeader;
+
+// if (_utils.__DEV__) {
+//   ModalHeader.displayName = "ModalHeader";
+// }

--- a/src/components/subcomponents/ModalOverlay.tsx
+++ b/src/components/subcomponents/ModalOverlay.tsx
@@ -1,0 +1,34 @@
+
+
+// var ModalOverlay = /*#__PURE__*/(0, _system.forwardRef)(function (props, ref) {
+//   var className = props.className,
+//       transition = props.transition,
+//       rest = _objectWithoutPropertiesLoose(props, ["className", "transition"]);
+
+//   var _className = (0, _utils.cx)("chakra-modal__overlay", className);
+
+//   var styles = (0, _system.useStyles)();
+
+//   var overlayStyle = _extends({
+//     pos: "fixed",
+//     left: "0",
+//     top: "0",
+//     w: "100vw",
+//     h: "100vh"
+//   }, styles.overlay);
+
+//   var _useModalContext4 = useModalContext(),
+//       motionPreset = _useModalContext4.motionPreset;
+
+//   var motionProps = motionPreset === "none" ? {} : _transition.fadeConfig;
+//   return /*#__PURE__*/React.createElement(Motion, _extends({}, motionProps, {
+//     __css: overlayStyle,
+//     ref: ref,
+//     className: _className
+//   }, rest));
+// });
+// exports.ModalOverlay = ModalOverlay;
+
+// if (_utils.__DEV__) {
+//   ModalOverlay.displayName = "ModalOverlay";
+// }

--- a/src/components/subcomponents/NumberInput.tsx
+++ b/src/components/subcomponents/NumberInput.tsx
@@ -1,0 +1,1 @@
+/// TODO: Replace Chakra NumberInput (and NumberInputField) here

--- a/src/components/subcomponents/Stack.tsx
+++ b/src/components/subcomponents/Stack.tsx
@@ -1,0 +1,4 @@
+/// TODO: Replace Chakra Stack component. This should be extremely simple, just a div with flex column.
+/// We may need to fine tune the sizing for mobile, etc., however.
+/// Also, we may want to rename from Stack -> Grid or something, as Stack may be Chakra-exclusive terminology.
+/// See also: Box.tsx

--- a/src/components/subcomponents/Text.tsx
+++ b/src/components/subcomponents/Text.tsx
@@ -1,0 +1,1 @@
+/// TODO: Adapt Chakra Text component, with some default styles inline.

--- a/src/components/subcomponents/index.tsx
+++ b/src/components/subcomponents/index.tsx
@@ -1,0 +1,1 @@
+/// TODO: export all subcomponents in this directory.


### PR DESCRIPTION
Development path for this change:
- Add subcomponents directory, make subcomponents that will replace Chakra components both stylistically and functionally. This will include some adapting work (from Chakra's base library) and some reverse engineering (what can't be discerned from library, we have to deduce from computed styles, etc.)
- Rebuild it from the ground up, replacing one component at a time, starting with small ones (e.g. Button) then finishing with overall ModalContent, ModalOverlay, etc. Iterate through this using comparison between the look/behavior [hosted demo](https://console.aws.amazon.com/amplify/home?region=us-east-1#/d2ux159cptlkki) and a local build.
- Final stage of dev will be to do some error driven development; put together the whole thing and unplug Chakra from package.json. Remove all framework-related dependencies, until the UI runs as-is, independently.
- Last thing is an integration test of all the different Modal screens. Make sure all the functionality is still there.