### PR TITLE
Keep the deposit listener when using onSwap

### DIFF
--- a/modules/widget/src/components/Modal.tsx
+++ b/modules/widget/src/components/Modal.tsx
@@ -228,7 +228,8 @@ const ConnextModal: FC<ConnextModalProps> = ({
 
       setIsLoad(false);
 
-      await handleSwap();
+      console.log(`Starting block listener`);
+      await depositListenerAndTransfer();
     } else if (webProvider) {
       // deposit
       try {


### PR DESCRIPTION
When using `onSwap`, I still want the modal to listen to transfers and only then trigger the actual Connext cross-chain swap, or else I'm keep getting `Asset not in channel` errors when trying to swap because the deposit meta-transaction doesn't get confirmed immediately - it takes a while for the funds to get into the state channel. Ideally, I still want the 'Waiting for transaction...' button but at the same time have the listener running.