### PR TITLE
Fix BlockScout wrong explorer token link

### DIFF
--- a/modules/sdk/src/utils/explorers.ts
+++ b/modules/sdk/src/utils/explorers.ts
@@ -52,5 +52,9 @@ export const getExplorerLinkForAsset = (chainId: number, assetId: string): strin
   if (assetId === constants.AddressZero) {
     return base;
   }
+  // BlockScout uses 'tokens' and not 'token'
+  if (chainId === 137 || chainId === 80001) {
+    return `${base}/tokens/${assetId}`;
+  }
   return `${base}/token/${assetId}`;
 };


### PR DESCRIPTION
This doesn't work:
https://explorer-mumbai.maticvigil.com/token/0x48987E8B356e0dE474ddE9Bc10541F8106C88A23

While this does:
https://explorer-mumbai.maticvigil.com/tokens/0x48987E8B356e0dE474ddE9Bc10541F8106C88A23

@sanchaymittal 